### PR TITLE
Prevent Duplicate count

### DIFF
--- a/whatsapp_stats.py
+++ b/whatsapp_stats.py
@@ -190,10 +190,10 @@ def update_common_words(person, message):
 	for word in words:
 		if not word.isspace() and len(word) > 2:
 			if word.lower() not in stopwords:
-				if word in person.common_words:
-					person.common_words[word] += 1
+				if word.lower() in person.common_words:
+					person.common_words[word.lower()] += 1
 				else:
-					person.common_words[word] = 1
+					person.common_words[word.lower()] = 1
 
 
 # PVDW - Return true is message was Media - Android compatibility


### PR DESCRIPTION
Change to prevent the same word from being counted as seperate due to
case. eg. Love and love

Converted all dictionary words to lower case before comparing and adding the word/count to a person's dictionary.
